### PR TITLE
Fixing HW/SW Inventory parsing and host matching under CMK 2.5.0p8

### DIFF
--- a/lib/python3/labelpicker/ds_plugins/lpds_hwswtree.py
+++ b/lib/python3/labelpicker/ds_plugins/lpds_hwswtree.py
@@ -67,6 +67,7 @@ class lpds_hwswtree(Strategy):
                     content = content.replace("null", "None")
                     
                     try:
+                        host = re.sub(r'\.json$', '', host)
                         parsed[host] = ast.literal_eval(content)
                     except SyntaxError as e:
                         print(f"Syntax error in file {host}: {e}")

--- a/lib/python3/labelpicker/ds_plugins/lpds_hwswtree.py
+++ b/lib/python3/labelpicker/ds_plugins/lpds_hwswtree.py
@@ -61,6 +61,11 @@ class lpds_hwswtree(Strategy):
                     print(f"DEBUG: Parsing {host}")
                 with open(f"{inventory_dir}/{host}", "r") as file:
                     content = file.read()
+
+                    content = content.replace("false", "False")
+                    content = content.replace("true", "True")
+                    content = content.replace("null", "None")
+                    
                     try:
                         parsed[host] = ast.literal_eval(content)
                     except SyntaxError as e:


### PR DESCRIPTION
I am running this extension under CMK 2.5.0p8 and had to implement these changes to make it work

1. The JSON file from CheckMK adheres to the JSON standard which ast.literal_eval() does not really like, so I had to replace `false`, `true`, and `null` with the Python equivalents
2. The extension does not find the host because the file name ends in `.json`

All these changes should be backwards compatible, but someone else has to check with a CMK 2.4.0 instance, I do not have the resources to do so